### PR TITLE
ESA Cloud_cci+ integration

### DIFF
--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -101,6 +101,8 @@ def cci_read_all(filename):
     logger.debug("Not reading surface temperature")
     logger.debug("Reading cloud phase")
     cloudproducts.cpp = read_cci_phase(cci_nc)
+    logger.debug("Reading LWP")
+    cloudproducts.cpp = read_cci_lwp(cci_nc, cloudproducts.cpp)
     logger.debug("Not reading channel data")
     if cci_nc:
         cci_nc.close()
@@ -145,6 +147,18 @@ def read_cci_phase(cci_nc):
     # else:
     #    phase_out = phase.data
     # print phase
+    return cpp_obj
+  
+  
+  def read_cci_lwp(cci_nc, cpp_obj):
+    """ Read LWP from CCI file 
+    """
+    data = cci_nc.variables['cwp'][::]
+    data = np.squeeze(data)
+    # split LWP from CWP
+    data = np.where(cpp_obj.cpp_phase == 2, ATRAIN_MATCH_NODATA, data)
+    data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
+    setattr(cpp_obj, 'cpp_lwp', data)
     return cpp_obj
 
 

--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -136,7 +136,7 @@ def read_cci_phase(cci_nc):
     """Read angles info from filename
     """
     cpp_obj = CppObj()
-    data = cci_nc.variables['phase'][::]
+    data = cci_nc.variables['ann_phase'][::]
     setattr(cpp_obj, 'cpp_phase', data)
     # if hasattr(phase, 'mask'):
     #    phase_out = np.where(phase.mask, -999, phase.data)

--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -137,6 +137,8 @@ def read_cci_phase(cci_nc):
     """
     cpp_obj = CppObj()
     data = cci_nc.variables['ann_phase'][::]
+    data = np.squeeze(data)
+    
     setattr(cpp_obj, 'cpp_phase', data)
     # if hasattr(phase, 'mask'):
     #    phase_out = np.where(phase.mask, -999, phase.data)

--- a/atrain_match/libs/extract_imager_along_track.py
+++ b/atrain_match/libs/extract_imager_along_track.py
@@ -326,7 +326,9 @@ def imager_track_from_matched(obt, SETTINGS, cloudproducts,
                                                          get_darkest_values,
                                                          get_warmest_values)
 
-    imager_channels = [key for key in imager_obj.channel if 'ch_' in key]
+    if imager_obj is not None:
+        imager_channels = [key for key in imager_obj.channel if 'ch_' in key]
+
     if imager_obj is not None and SETTINGS["SAVE_NEIGHBOUR_INFO"]  and extract_radiances:
         warm_row_col = get_warmest_values(imager_obj, row_col)
         for key in imager_channels:
@@ -346,10 +348,11 @@ def imager_track_from_matched(obt, SETTINGS, cloudproducts,
             atrain_name = 'darkest_'  + atrain_name.replace('micron',''). replace('b','')
             data = get_channel_data_from_object(imager_obj, key, dark_row_col)
             setattr(obt.imager, atrain_name, data)
-            
-    if 'qual_flags' in imager_obj.channel:
-        qual = imager_obj.channel['qual_flags'].data
-        setattr(obt.imager, 'qual_flags', qual[truth.imager_linnum,:])
+
+    if imager_obj is not None:            
+        if 'qual_flags' in imager_obj.channel:
+            qual = imager_obj.channel['qual_flags'].data
+            setattr(obt.imager, 'qual_flags', qual[truth.imager_linnum,:])
         
     # Imager data        
     if imager_obj is not None and extract_radiances:

--- a/atrain_match/statistics/orrb_CFC_stat.py
+++ b/atrain_match/statistics/orrb_CFC_stat.py
@@ -100,6 +100,10 @@ class CloudFractionStats(OrrbStats):
         kuipers = np.divide(1.0 * (n_clear_clear_cal * n_cloudy_cloudy_cal - n_cloudy_clear_cal * n_clear_cloudy_cal),
                             ((n_clear_clear_cal + n_clear_cloudy_cal) * (n_cloudy_clear_cal + n_cloudy_cloudy_cal)))
 
+        heidke = np.divide(2.0 * ((n_clear_clear_cal * n_cloudy_cloudy_cal)- (n_cloudy_clear_cal * n_clear_cloudy_cal)),
+                            ((n_clear_clear_cal + n_clear_cloudy_cal)*(n_clear_cloudy_cal + n_cloudy_cloudy_cal) + \
+                            (n_clear_clear_cal + n_cloudy_clear_cal)*(n_cloudy_clear_cal + n_cloudy_cloudy_cal)))
+
         hitrate = np.divide(1.0 * (n_clear_clear_cal + n_cloudy_cloudy_cal),
                             (n_clear_clear_cal + n_clear_cloudy_cal + n_cloudy_clear_cal + n_cloudy_cloudy_cal))
 
@@ -181,6 +185,7 @@ class CloudFractionStats(OrrbStats):
         lines.append("FAR cloudy: {:6.2f}".format(self.far_cloudy_cal))
         lines.append("FAR clear:  {:6.2f}".format(self.far_clear_cal))
         lines.append("Kuipers: {:5.3f}".format(self.kuipers))
+        lines.append("Heidke: {:5.3f}".format(self.heidke))
         lines.append("Hitrate: {:5.3f}".format(self.hitrate))
         lines.append("")
         if "step_cmaprob" in self.ac_data.keys():

--- a/atrain_match/statistics/orrb_CFC_stat.py
+++ b/atrain_match/statistics/orrb_CFC_stat.py
@@ -83,7 +83,8 @@ class CloudFractionStats(OrrbStats):
                          n_clear_clear_cal,
                          Num)
 
-        mean_CFC_cal = 100. * scu.mean()
+        mean_CFC_cal = 100. * scu.mean(n_cloudy_cloudy_cal, n_cloudy_clear_cal)
+        mean_CFC_img = 100 * scu.mean(n_cloudy_cloudy_cal, n_clear_cloudy_cal)
         bias_cal = scu.bias()
         bias_cal_perc = 100. * bias_cal
         pod_cloudy_cal = 100. * scu.pod_1()
@@ -133,6 +134,7 @@ class CloudFractionStats(OrrbStats):
             self.hitrate_MODIS = hitrate_MODIS
         self.Num = Num
         self.mean_CFC_cal = mean_CFC_cal
+        self.mean_CFC_img = mean_CFC_img
         self.bias_cal_perc = bias_cal_perc
         self.rms_cal = rms_cal
         self.pod_cloudy_cal = pod_cloudy_cal
@@ -163,6 +165,7 @@ class CloudFractionStats(OrrbStats):
         lines.append("")
         lines.append("Total number of {:s} matched FOVs: {:.0f}".format(self.truth_sat.upper(), self.Num))
         lines.append("Mean CFC {:s}: {:6.2f} ".format(self.truth_sat.upper(), self.mean_CFC_cal))
+        lines.append("Mean CFC imager: {:6.2f} ".format(self.mean_CFC_img))
         lines.append("Mean error: {:6.2f}".format(self.bias_cal_perc))
         lines.append("RMS error:  {:6.2f}".format(self.rms_cal))
         lines.append("POD cloudy: {:6.2f}".format(self.pod_cloudy_cal))

--- a/atrain_match/statistics/orrb_CFC_stat.py
+++ b/atrain_match/statistics/orrb_CFC_stat.py
@@ -24,7 +24,7 @@ import math
 import numpy as np
 
 from atrain_match.statistics.orrb_stat_class import OrrbStats
-
+from atrain_match.statistics.scores import ScoreUtils
 # -----------------------------------------------------
 
 
@@ -61,14 +61,6 @@ class CloudFractionStats(OrrbStats):
             detected_clear = np.array([np.sum(n_clear_cmaprob[max_prob <= limit]) for limit in limit_v])
             false_clouds = np.array([np.sum(n_clear_cmaprob[max_prob > limit]) for limit in limit_v])
 
-            print(max_prob)
-            print(limit_v)
-
-            print(false_clouds)
-            print(detected_clear)
-            print(detected_clouds)
-            print(undetected_clouds)
-
             pod_cloudy_prob = 100.0 / Num_cloudy_tot * detected_clouds
             pod_clear_prob = 100.0 / Num_clear_tot * detected_clear
             far_cloudy_prob = 100.0 * false_clouds / (false_clouds + detected_clouds)
@@ -85,57 +77,49 @@ class CloudFractionStats(OrrbStats):
 
         Num = self.ac_data["Num"]
 
-        mean_CFC_cal = np.divide(100.0 * (n_cloudy_cloudy_cal + n_cloudy_clear_cal), Num)
-        bias_cal = np.divide(1. * (n_clear_cloudy_cal - n_cloudy_clear_cal), Num)
-        bias_cal_perc = np.divide(100.0 * (n_clear_cloudy_cal - n_cloudy_clear_cal), Num)
+        scu = ScoreUtils(n_cloudy_cloudy_cal,
+                         n_clear_cloudy_cal,
+                         n_cloudy_clear_cal,
+                         n_clear_clear_cal,
+                         Num)
+
+        mean_CFC_cal = 100. * scu.mean()
+        bias_cal = scu.bias()
+        bias_cal_perc = 100. * bias_cal
+        pod_cloudy_cal = 100. * scu.pod_1()
+        pod_clear_cal = 100. * scu.pod_0()
+        far_cloudy_cal = 100. * scu.far_1()
+        far_clear_cal = 100. * scu.far_0()
+        kuipers = scu.kuiper()
+        heidke = scu.heidke()
+        hitrate = scu.hitrate()        
+
         square_sum_cal = (n_clear_clear_cal + n_cloudy_cloudy_cal) * bias_cal**2 + \
-            n_cloudy_clear_cal * (-1.0 - bias_cal)**2 + \
-            n_clear_cloudy_cal * (1.0 - bias_cal)**2
-        rms_cal = 100.0 * math.sqrt(np.divide(square_sum_cal, Num - 1.))
-        pod_cloudy_cal = np.divide(100.0 * n_cloudy_cloudy_cal, (n_cloudy_cloudy_cal + n_cloudy_clear_cal))
-        pod_clear_cal = np.divide(100.0 * n_clear_clear_cal, n_clear_clear_cal + n_clear_cloudy_cal)
-        far_cloudy_cal = np.divide(100.0 * n_clear_cloudy_cal, n_cloudy_cloudy_cal + n_clear_cloudy_cal)
-        far_clear_cal = np.divide(100.0 * n_cloudy_clear_cal, n_clear_clear_cal + n_cloudy_clear_cal)
-
-        kuipers = np.divide(1.0 * (n_clear_clear_cal * n_cloudy_cloudy_cal - n_cloudy_clear_cal * n_clear_cloudy_cal),
-                            ((n_clear_clear_cal + n_clear_cloudy_cal) * (n_cloudy_clear_cal + n_cloudy_cloudy_cal)))
-
-        heidke = np.divide(2.0 * ((n_clear_clear_cal * n_cloudy_cloudy_cal)- (n_cloudy_clear_cal * n_clear_cloudy_cal)),
-                            ((n_clear_clear_cal + n_clear_cloudy_cal)*(n_clear_cloudy_cal + n_cloudy_cloudy_cal) + \
-                            (n_clear_clear_cal + n_cloudy_clear_cal)*(n_cloudy_clear_cal + n_cloudy_cloudy_cal)))
-
-        hitrate = np.divide(1.0 * (n_clear_clear_cal + n_cloudy_cloudy_cal),
-                            (n_clear_clear_cal + n_clear_cloudy_cal + n_cloudy_clear_cal + n_cloudy_cloudy_cal))
+            n_cloudy_clear_cal * (-1. - bias_cal)**2 + \
+            n_clear_cloudy_cal * (1. - bias_cal)**2
+        rms_cal = 100. * math.sqrt(np.divide(square_sum_cal, Num - 1.))
 
         # MODIS
         if self.ac_data["got_cloudsat_modis_flag"]:
-            bias_modis = np.divide(1. * (n_clear_cloudy_cal_MODIS - n_cloudy_clear_cal_MODIS), Num - 1.)
-            bias_modis_perc = np.divide(100.0 * (n_clear_cloudy_cal_MODIS - n_cloudy_clear_cal_MODIS), Num - 1.)
+            scu_modis = ScoreUtils(n_cloudy_cloudy_cal_MODIS,
+                                   n_clear_cloudy_cal_MODIS,
+                                   n_cloudy_clear_cal_MODIS,
+                                   n_clear_clear_cal_MODIS,
+                                   Num)
+
+            bias_modis = scu_modis.bias()
+            bias_modis_perc = 100. * bias_modis
+            pod_cloudy_cal_MODIS = 100. * scu_modis.pod_1()
+            pod_clear_cal_MODIS = 100. * scu_modis.pod_0()
+            far_cloudy_cal_MODIS = 100. * scu_modis.far_1()
+            far_clear_cal_MODIS = 100. * scu_modis.far_0()
+            kuipers_MODIS = scu_modis.kuiper()
+            hitrate_MODIS = scu_modis.hitrate()
+            
             square_sum_modis = (n_clear_clear_cal + n_cloudy_cloudy_cal) * bias_modis**2 + \
-                n_cloudy_clear_cal * (-1.0 - bias_modis)**2 + \
-                n_clear_cloudy_cal * (1.0 - bias_modis)**2
-            rms_modis = 100.0 * math.sqrt(np.divide(square_sum_modis, Num - 1.))
-            pod_cloudy_cal_MODIS = np.divide(
-                100.0 * n_cloudy_cloudy_cal_MODIS,
-                n_cloudy_cloudy_cal_MODIS + n_cloudy_clear_cal_MODIS)
-            pod_clear_cal_MODIS = np.divide(
-                100.0 * n_clear_clear_cal_MODIS,
-                n_clear_clear_cal_MODIS + n_clear_cloudy_cal_MODIS)
-            far_cloudy_cal_MODIS = np.divide(
-                100.0 * n_clear_cloudy_cal_MODIS,
-                n_cloudy_cloudy_cal_MODIS + n_clear_cloudy_cal_MODIS)
-            far_clear_cal_MODIS = np.divide(
-                100.0 * n_cloudy_clear_cal_MODIS,
-                n_clear_clear_cal_MODIS + n_cloudy_clear_cal_MODIS)
-            kuipers_MODIS = np.divide(
-                1.0 * (n_clear_clear_cal_MODIS * n_cloudy_cloudy_cal_MODIS -
-                       n_cloudy_clear_cal_MODIS * n_clear_cloudy_cal_MODIS),
-                ((n_clear_clear_cal_MODIS + n_clear_cloudy_cal_MODIS) *
-                 (n_cloudy_clear_cal_MODIS + n_cloudy_cloudy_cal_MODIS)))
-            hitrate_MODIS = np.divide(
-                1.0 * (n_clear_clear_cal_MODIS + n_cloudy_cloudy_cal_MODIS),
-                (n_clear_clear_cal_MODIS + n_clear_cloudy_cal_MODIS +
-                 n_cloudy_clear_cal_MODIS + n_cloudy_cloudy_cal_MODIS))
+                n_cloudy_clear_cal * (-1. - bias_modis)**2 + \
+                n_clear_cloudy_cal * (1. - bias_modis)**2
+            rms_modis = 100. * math.sqrt(np.divide(square_sum_modis, Num - 1.))
 
         # Store values of interest as attributes
         if self.ac_data["got_cloudsat_modis_flag"]:

--- a/atrain_match/statistics/orrb_CFC_stat.py
+++ b/atrain_match/statistics/orrb_CFC_stat.py
@@ -140,6 +140,7 @@ class CloudFractionStats(OrrbStats):
         self.far_cloudy_cal = far_cloudy_cal
         self.far_clear_cal = far_clear_cal
         self.kuipers = kuipers
+        self.heidke = heidke
         self.hitrate = hitrate
         if "step_cmaprob" in self.ac_data.keys():
             self.pod_clear_prob = pod_clear_prob

--- a/atrain_match/statistics/orrb_CPH_stat.py
+++ b/atrain_match/statistics/orrb_CPH_stat.py
@@ -37,6 +37,8 @@ class CloudPhaseStats(OrrbStats):
         n_water_water_cal = self.ac_data["n_water_water_cal"]
         Num = self.ac_data["Num"]
 
+        bias_cal = np.divide(1. * (n_ice_water_cal - n_water_ice_cal), Num)
+
         pod_water_cal = np.divide(100.0 * n_water_water_cal,
                                   (n_water_water_cal + n_water_ice_cal))
         pod_ice_cal = np.divide(100.0 * n_ice_ice_cal,
@@ -52,6 +54,14 @@ class CloudPhaseStats(OrrbStats):
             ((n_ice_ice_cal + n_ice_water_cal) *
              (n_water_ice_cal + n_water_water_cal)))
 
+        heidke = np.divide(2.0 * ((n_ice_ice_cal * n_water_water_cal) - \
+                           (n_water_ice_cal * n_ice_water_cal)), \
+                           ((n_ice_ice_cal + n_ice_water_cal)* \ 
+                           (n_ice_water_cal + n_water_water_cal) + \
+                           (n_ice_ice_cal + n_water_ice_cal)* \
+                           (n_water_ice_cal + n_water_water_cal)))
+
+
         hitrate = np.divide(
             1.0 * (n_ice_ice_cal + n_water_water_cal),
             (n_ice_ice_cal + n_ice_water_cal +
@@ -60,10 +70,12 @@ class CloudPhaseStats(OrrbStats):
         # Store values of interest as attributes
         self.Num = Num
         self.pod_water_cal = pod_water_cal
+        self.bias_cal = bias_cal
         self.pod_ice_cal = pod_ice_cal
         self.far_water_cal = far_water_cal
         self.far_ice_cal = far_ice_cal
         self.cph_kuipers = kuipers
+        self.cph_heidke = heidke
         self.cph_hitrate = hitrate
         self.n_water = n_water_water_cal + n_water_ice_cal
         self.n_ice = n_ice_ice_cal + n_ice_water_cal
@@ -78,12 +90,14 @@ class CloudPhaseStats(OrrbStats):
                      % self.ac_data["scenes"])
         lines.append("Total number of %s matched FOVs: %d"
                      % (self.truth_sat.upper(), self.Num))
+        lines.append("Mean error: %.2f" % self.bias_cal)
         lines.append("POD water: %.2f" % self.pod_water_cal)
         lines.append("FAR water: %.2f" % self.far_water_cal)
         lines.append("POD ice: %.2f" % self.pod_ice_cal)
         lines.append("FAR ice: %.2f" % self.far_ice_cal)
         lines.append("CPH Hitrate: %.2f" % self.cph_hitrate)
         lines.append("CPH Kuipers: %.2f" % self.cph_kuipers)
+        lines.append("CPH Heidke: %.2f" % self.cph_heidke)
         lines.append("CPH N Water: %.2f" % self.n_water)
         lines.append("CPH N Ice: %.2f" % self.n_ice)
         lines.append("CPH N Water ok: %.2f" % self.n_water_water)

--- a/atrain_match/statistics/orrb_CPH_stat.py
+++ b/atrain_match/statistics/orrb_CPH_stat.py
@@ -23,7 +23,7 @@
 import numpy as np
 
 from atrain_match.statistics.orrb_stat_class import OrrbStats
-
+from atrain_match.statistics.scores import ScoreUtils
 # -----------------------------------------------------
 
 
@@ -31,52 +31,27 @@ class CloudPhaseStats(OrrbStats):
     def do_stats(self):
         OrrbStats.do_stats(self)
 
-        n_ice_ice_cal = self.ac_data["n_ice_ice_cal"]
-        n_ice_water_cal = self.ac_data["n_ice_water_cal"]
-        n_water_ice_cal = self.ac_data["n_water_ice_cal"]
-        n_water_water_cal = self.ac_data["n_water_water_cal"]
+        n_ice_ice_cal = self.ac_data["n_ice_ice_cal"]  # a 
+        n_ice_water_cal = self.ac_data["n_ice_water_cal"]  #c 
+        n_water_ice_cal =  self.ac_data["n_water_ice_cal"]  # b
+        n_water_water_cal = self.ac_data["n_water_water_cal"]  # d
         Num = self.ac_data["Num"]
 
-        bias_cal = np.divide(1. * (n_ice_water_cal - n_water_ice_cal), Num)
-
-        pod_water_cal = np.divide(100.0 * n_water_water_cal,
-                                  (n_water_water_cal + n_water_ice_cal))
-        pod_ice_cal = np.divide(100.0 * n_ice_ice_cal,
-                                n_ice_ice_cal + n_ice_water_cal)
-        far_water_cal = np.divide(100.0 * n_ice_water_cal,
-                                  n_water_water_cal + n_ice_water_cal)
-        far_ice_cal = np.divide(100.0 * n_water_ice_cal,
-                                n_ice_ice_cal + n_water_ice_cal)
-
-        kuipers = np.divide(
-            1.0 * (n_ice_ice_cal * n_water_water_cal -
-                   n_water_ice_cal * n_ice_water_cal),
-            ((n_ice_ice_cal + n_ice_water_cal) *
-             (n_water_ice_cal + n_water_water_cal)))
-
-        heidke = np.divide(2.0 * ((n_ice_ice_cal * n_water_water_cal) - \
-                           (n_water_ice_cal * n_ice_water_cal)), \
-                           ((n_ice_ice_cal + n_ice_water_cal)* \ 
-                           (n_ice_water_cal + n_water_water_cal) + \
-                           (n_ice_ice_cal + n_water_ice_cal)* \
-                           (n_water_ice_cal + n_water_water_cal)))
-
-
-        hitrate = np.divide(
-            1.0 * (n_ice_ice_cal + n_water_water_cal),
-            (n_ice_ice_cal + n_ice_water_cal +
-             n_water_ice_cal + n_water_water_cal))
-
+        scu = ScoreUtils(n_ice_ice_cal,
+                         n_water_ice_cal,
+                         n_ice_water_cal,
+                         n_water_water_cal)
+        
         # Store values of interest as attributes
         self.Num = Num
-        self.pod_water_cal = pod_water_cal
-        self.bias_cal = bias_cal
-        self.pod_ice_cal = pod_ice_cal
-        self.far_water_cal = far_water_cal
-        self.far_ice_cal = far_ice_cal
-        self.cph_kuipers = kuipers
-        self.cph_heidke = heidke
-        self.cph_hitrate = hitrate
+        self.pod_water_cal = 100. * scu.pod_0()
+        self.bias_cal = scu.bias()
+        self.pod_ice_cal = 100. * scu.pod_1()
+        self.far_water_cal = 100. * scu.far_0()
+        self.far_ice_cal = 100 * scu.far_1()
+        self.cph_kuipers = scu.kuiper()
+        self.cph_heidke = scu.heidke()
+        self.cph_hitrate = scu.hitrate()
         self.n_water = n_water_water_cal + n_water_ice_cal
         self.n_ice = n_ice_ice_cal + n_ice_water_cal
         self.n_water_water = n_water_water_cal

--- a/atrain_match/statistics/scores.py
+++ b/atrain_match/statistics/scores.py
@@ -1,0 +1,125 @@
+""" Module containing functions to calculate various scores """
+import numpy as np
+
+class ScoreUtils:
+    def __init__(self, a, b, c, d, num=None):
+
+        """ 
+        Initialize ScoreUtils class. Takes contigency table elements 
+        as arguments (see below).
+
+                                  Observed
+                 |   yes           |         no             |   Total
+            -----+-----------------+------------------------+---------------
+        FC   yes |      hits (a)   | false alarms (b)       | forecast yes
+              no |     misses (c)  | correct negatives (d)  | forecast no
+            -----+-----------------+------------------------+---------------
+             Tot |  observed yes   | observed no            |    total (n)
+
+        Argument num is an optional argument to insert a different total sum 
+        for statistics using e.g. n-1 as denominator. If not provided, num 
+        is calculated as a + b + c + d.
+
+        """
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        if num is not None:
+            self.n = num
+        else
+            self.n = a + b + c + d
+
+    def hitrate(self):
+        """
+        Calculates the hitrate (fraction correct).
+
+        Range: 0 to 1
+        Perfect score: 1
+        """
+        return np.divide(self.a + self.d, self.n)
+
+    def pod_0(self):
+        """
+        Calculates probability of detecting 0 (clr/wat).
+
+        Range: 0 to 1
+        Perfect score: 1
+        """
+        return np.divide(self.d, self.b + self.d)
+
+    def pod_1(self):
+        """
+        Calculates probability of detecting 1 (cld/ice).
+
+        Range: 0 to 1
+        Perfect score: 1
+        """
+        return np.divide(self.a, self.a + self.c)
+
+    def far_0(self):
+        """
+        Calculates the 0 (clr/wat) false alarm rate.
+
+        Range: 0 to 1
+        Perfect score: 0
+        """
+        return np.divide(self.c, self.c + self.d)
+
+    def far_1(self):
+        """
+        Calculates the 1 (cld/ice) false alarm rate.
+
+        Range: 0 to 1
+        Perfect score: 0
+        """
+        return np.divide(self.b, self.a + self.b)
+
+    def pofd_0(self):
+        """
+        Calculates the probability of false detection for 0 (clr/wat).
+
+        Range: 0 to 1
+        Perfect score: 0
+        """
+        return np.divide(self.c, self.a + self.c)
+
+    def pofd_1(self):
+        """
+        Calculates the probability of false detection for 1 (cld/ice).
+
+        Range: 0 to 1
+        Perfect score: 0
+        """
+        return np.divide(self.b, self.b + self.d)
+
+    def heidke(self):
+        """
+        Calculates the Heidke skill score.
+
+        Range: -1 to 1, 0 indicates no skill
+        Perfect score: 1
+        """
+        num = 2 * ((self.a * self.d) - (self.b * self.c))
+        denom = ((self.a + self.c) * (self.c + self.d) +\
+                 (self.a + self.b) * (self.b + self.d))
+        return np.divide(num, denom)
+
+    def kuiper(self):
+        """
+        Calculates the Hansen Kuiper skill score.
+
+        Range: -1 to 1, 0 indicates no skill
+        Perfect score: 1
+        """
+        num = (self.a * self.d - self.b * self.c)
+        denom = (self.a + self.c) * (self.b + self.d)
+        return np.divide(num, denom)
+
+    def bias(self):
+        """ Calculates the bias (mean error). """
+        return np.divide(self.b - self.c, self.n)
+
+    def mean(self):
+        """ Calculates the mean. """       
+        return np.divide(self.a + self.c), self.n)

--- a/atrain_match/statistics/scores.py
+++ b/atrain_match/statistics/scores.py
@@ -27,7 +27,7 @@ class ScoreUtils:
         self.d = d
         if num is not None:
             self.n = num
-        else
+        else:
             self.n = a + b + c + d
 
     def hitrate(self):
@@ -122,4 +122,4 @@ class ScoreUtils:
 
     def mean(self):
         """ Calculates the mean. """       
-        return np.divide(self.a + self.c), self.n)
+        return np.divide(self.a + self.c, self.n)

--- a/atrain_match/statistics/scores.py
+++ b/atrain_match/statistics/scores.py
@@ -2,7 +2,8 @@
 import numpy as np
 
 class ScoreUtils:
-    def __init__(self, a, b, c, d, num=None):
+    def __init__(self, hits, false_alarms, misses, 
+                 correct_negatives, num=None):
 
         """ 
         Initialize ScoreUtils class. Takes contigency table elements 
@@ -21,14 +22,14 @@ class ScoreUtils:
         is calculated as a + b + c + d.
 
         """
-        self.a = a
-        self.b = b
-        self.c = c
-        self.d = d
+        self.a = hits
+        self.b = false_alarms
+        self.c = misses
+        self.d = correct_negatives
         if num is not None:
             self.n = num
         else:
-            self.n = a + b + c + d
+            self.n = self.a + self.b + self.c + self.d
 
     def hitrate(self):
         """

--- a/atrain_match/statistics/scores.py
+++ b/atrain_match/statistics/scores.py
@@ -120,6 +120,6 @@ class ScoreUtils:
         """ Calculates the bias (mean error). """
         return np.divide(self.b - self.c, self.n)
 
-    def mean(self):
+    def mean(self, x, y):
         """ Calculates the mean. """       
-        return np.divide(self.a + self.c, self.n)
+        return np.divide(x + y, self.n)

--- a/atrain_match/utils/runutils.py
+++ b/atrain_match/utils/runutils.py
@@ -180,16 +180,29 @@ def parse_scenesfile_v2014(filename):
 def parse_scenesfile_cci(filename):
     """
     Parse cci file: 20080613002200-ESACCI-L2_CLOUD-CLD_PRODUCTS-IMAGERGAC-NOAA18-fv1.0.nc
+    OR
+    Parse cci file: 20190713002200-ESACCI-L2_CLOUD-CLD_PRODUCTS-SEVIRI-MSG4-fv1.0.nc
     """
     from datetime import datetime
     import re
     filename = os.path.basename(filename)
     if not filename:
         raise ValueError("No file %r" % filename)
-    match = re.match(
-        r"(\d\d\d\d\d\d\d\d)(\d\d\d\d).+IMAGERGAC-([^-]+)-", filename)
+
+    # CCI data
+    if "IMAGERGAC" in filename:
+        match = re.match(
+            r"(\d\d\d\d\d\d\d\d)(\d\d\d\d).+IMAGERGAC-([^-]+)-", filename)
+    # CCI+ data
+    elif "SEVIRI" in filename:
+        match = re.match(
+            r"(\d\d\d\d\d\d\d\d)(\d\d\d\d).+SEVIRI-([^-]+)-", filename)
+    else:
+        raise ValueError("atrain_match not able to handle %r files" % filename)
+
     if not match:
         raise ValueError("Couldn't parse cci file %r" % filename)
+
     date_s, time_s, satname = match.groups()
     _datetime = datetime.strptime(date_s + time_s, '%Y%m%d%H%M')
 


### PR DESCRIPTION
Hi all,

I am working within the ESA Cloud_cci+ project and closely together with the CMSAF team. Martin mentioned some time ago that we plan to use atrain_match for validation of the CMSAF CLAAS and ESA Cloud_cci+ datasets (both SEVIRI). After some testing we now have atrain_match running successfully and already did some validation. 

For CCI I was able to get it running with some minor changes (see commits). You'll have a look at it for sure but I guess that my changes won't affect processing of other datasets.

Basically the changes include:
1. I changed the regular expression string getting information from the CCI filenames as those have changed slightly.
2. I added two times "if imager_obj is not None" as otherwise the code threw an error message into the output.
3. I added the Heidke skill score to the CMA and CPH statistics as we would like to have this score for our validation.
4. I cleaned up the statistics calculation for CPH and CMA by moving the score functions to an external file.

I created this PR now but still have to check if the statistics are calculated correctly as before. Maybe some commits will be added to this PR the next week :)  