### PR TITLE
Added AMSR2 support for LWP validation 

### DIFF
--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -103,10 +103,20 @@ def cci_read_all(filename):
     cloudproducts.cpp = read_cci_phase(cci_nc)
     logger.debug("Reading LWP")
     cloudproducts.cpp = read_cci_lwp(cci_nc, cloudproducts.cpp)
+    logger.debug("Reading LSM")
+    cloudproducts.aux = read_cci_lsm(cci_nc)
     logger.debug("Not reading channel data")
     if cci_nc:
         cci_nc.close()
     return cloudproducts
+  
+  
+def read_cci_lsm(cci_nc):
+    """ Read land-sea mask from CCI file.
+    """
+    fractionofland = cci_nc.variables['lsflag'][::]
+    aux = AuxiliaryObj({'fractionofland': fractionofland})
+    return aux
 
 
 def read_cci_cma(cci_nc):

--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -172,7 +172,7 @@ def read_cci_phase(cci_nc):
     data = np.squeeze(data)
     # split LWP from CWP
     data = np.where(cpp_obj.cpp_phase == 2, ATRAIN_MATCH_NODATA, data)
-    #data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
+    data = np.where(data <= 0, ATRAIN_MATCH_NODATA, data)
     setattr(cpp_obj, 'cpp_lwp', data)
     return cpp_obj
 

--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -150,13 +150,18 @@ def read_cci_phase(cci_nc):
     cpp_obj = CppObj()
     data = cci_nc.variables['ann_phase'][::]
     data = np.squeeze(data)
-    
+    data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
     setattr(cpp_obj, 'cpp_phase', data)
-    # if hasattr(phase, 'mask'):
-    #    phase_out = np.where(phase.mask, -999, phase.data)
-    # else:
-    #    phase_out = phase.data
-    # print phase
+    
+    data = cci_nc.variables['qcflag'][::]
+    data = np.squeeze(data)
+    setattr(cpp_obj, 'cpp_quality', data)
+    
+    data = cci_nc.variables['cot'][::]
+    data = np.squeeze(data)
+    data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
+    setattr(cpp_obj, 'cpp_cot', data)
+    
     return cpp_obj
   
   

--- a/atrain_match/cloudproducts/read_cci.py
+++ b/atrain_match/cloudproducts/read_cci.py
@@ -172,7 +172,7 @@ def read_cci_phase(cci_nc):
     data = np.squeeze(data)
     # split LWP from CWP
     data = np.where(cpp_obj.cpp_phase == 2, ATRAIN_MATCH_NODATA, data)
-    data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
+    #data = np.where(data < 1, ATRAIN_MATCH_NODATA, data)
     setattr(cpp_obj, 'cpp_lwp', data)
     return cpp_obj
 

--- a/atrain_match/config.py
+++ b/atrain_match/config.py
@@ -115,3 +115,7 @@ PPS_FORMAT_2012_OR_EARLIER = False
 #  Surfaces for which statistics should be summarized
 SURFACES = PROCESS_SURFACES
 DNT_FLAG = ['ALL', 'DAY', 'NIGHT', 'TWILIGHT']
+
+# AMSR footprint size of 36 GHz channel
+AMSR_SEMI_MINOR_DIAMETER = 7000.
+AMSR_SEMI_MAJOR_DIAMETER = 12000.

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -35,7 +35,7 @@ AMSR_SENSOR = AMSR-E
 AMSR_ROF = -999
 # percentage of overlap a imager pixel has to have to be matched
 AMSR_OVERLAP = 0.5
-# define a radius for imager pixels representing their size
+# define a radius for imager pixels representing their size [m]
 # calculated as sqrt(xsize**2 + ysize**2)
 # for AVHRR GAC
 AMSR_GAC_PIXEL_RADIUS = 5325.

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -37,12 +37,8 @@ AMSR_ROF = -999
 AMSR_OVERLAP = 0.5
 # define a radius for imager pixels representing their size [m]
 # calculated as sqrt(xsize**2 + ysize**2)
-# for AVHRR GAC
-AMSR_GAC_PIXEL_RADIUS = 5325.
-# for SEVIRI lowres
-AMSR_SEVIRI_PIXEL_RADIUS = 5660.
-# for higher resolution sensors (MODIS, VIIRS, SLSTR...)
-AMSR_IMAGER_1KM_PIXEL_RADIUS = 1414.
+# recommended: AVHRR GAC: 5325 m, SEVIRI: 5660 m, 1km data: 1414 m
+AMSR_IMAGER_PIXEL_RADIUS = 5325.
 
 #========== SYNOP stuff ==========#
 SYNOP_RADIUS = 10.e3 

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -27,7 +27,7 @@ MINUTES_TIMETHR = 5
 #: For synop see below
 
 #=============== AMSR sensor ==============#
-#: Specifiy if sensor is AMSR-E or AMSR2
+#: Specifiy if sensor is AMSR-E or AMSR2_JAXA or AMSR2_NSIDC
 AMSR_SENSOR = AMSR-E
 
 #========== SYNOP stuff ==========#

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -30,7 +30,8 @@ MINUTES_TIMETHR = 5
 #: Specifiy if sensor is AMSR-E or AMSR2_JAXA or AMSR2_NSIDC
 AMSR_SENSOR = AMSR-E
 # set radius of influence (rof) for nearest neighbour search [m]
-# if < 0 rof is estimated internally using a formula 
+# if < 0 rof is estimated internally using a formula with AMSR_OVERLAP
+# and PIXEL_RADIUS
 AMSR_ROF = -999
 # percentage of overlap a imager pixel has to have to be matched
 AMSR_OVERLAP = 0.5

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -26,6 +26,10 @@ SAT_ORBIT_DURATION_MINUTES = 95
 MINUTES_TIMETHR = 5
 #: For synop see below
 
+#=============== AMSR sensor ==============#
+#: Specifiy if sensor is AMSR-E or AMSR2
+AMSR_SENSOR = AMSR-E
+
 #========== SYNOP stuff ==========#
 SYNOP_RADIUS = 10.e3 
 #: Traditional value 7/8

--- a/atrain_match/etc/atrain_match.cfg
+++ b/atrain_match/etc/atrain_match.cfg
@@ -26,9 +26,22 @@ SAT_ORBIT_DURATION_MINUTES = 95
 MINUTES_TIMETHR = 5
 #: For synop see below
 
-#=============== AMSR sensor ==============#
+#=============== AMSR stuff ==============#
 #: Specifiy if sensor is AMSR-E or AMSR2_JAXA or AMSR2_NSIDC
 AMSR_SENSOR = AMSR-E
+# set radius of influence (rof) for nearest neighbour search [m]
+# if < 0 rof is estimated internally using a formula 
+AMSR_ROF = -999
+# percentage of overlap a imager pixel has to have to be matched
+AMSR_OVERLAP = 0.5
+# define a radius for imager pixels representing their size
+# calculated as sqrt(xsize**2 + ysize**2)
+# for AVHRR GAC
+AMSR_GAC_PIXEL_RADIUS = 5325.
+# for SEVIRI lowres
+AMSR_SEVIRI_PIXEL_RADIUS = 5660.
+# for higher resolution sensors (MODIS, VIIRS, SLSTR...)
+AMSR_IMAGER_1KM_PIXEL_RADIUS = 1414.
 
 #========== SYNOP stuff ==========#
 SYNOP_RADIUS = 10.e3 

--- a/atrain_match/libs/truth_imager_match.py
+++ b/atrain_match/libs/truth_imager_match.py
@@ -1033,8 +1033,8 @@ def get_matchups_from_data(cross, AM_PATHS, SETTINGS):
                                        cloudproducts, SETTINGS)
     # AMSR
     amsr_matchup = None
-    if (SETTINGS['PPS_VALIDATION'] and SETTINGS['AMSR_MATCHING'] and
-            truth_files['amsr'] is not None):
+    if ((SETTINGS['CCI_CLOUD_VALIDATION'] or SETTINGS['PPS_VALIDATION']) 
+        and SETTINGS['AMSR_MATCHING'] and truth_files['amsr'] is not None):
         logger.info("Read AMSR data")
         amsr_matchup = get_amsr_matchups(truth_files['amsr'],
                                          cloudproducts, SETTINGS)

--- a/atrain_match/matchobject_io.py
+++ b/atrain_match/matchobject_io.py
@@ -343,7 +343,10 @@ class AmsrObject(DataObject):
             'imager_linnum_nneigh': None,
             'imager_pixnum_nneigh': None,
             'sec_1970': None,
-            'lwp': None}
+            'lwp': None,
+            'pixel_status': None,
+            'quality': None,
+            'surface_type': None}
 
 
 class MoraObject(DataObject):
@@ -570,6 +573,9 @@ the_used_variables = [
     # AMSR
     'lwp',
     'imager_amsr_dist',
+    'pixel_status',
+    'quality',
+    'surface_type',
     # MORA
     'cloud_base_height',
     # Cloudsat

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -115,18 +115,18 @@ def read_amsr2_h5(filename):
   
 
 def read_amsr2_he5(filename):
-  retv = AmsrObject()
-  with h5py.File(filename, 'r') as f:
-      geoloc = f['HDFEOS']['SWATHS']['AMSR2_L1R']['Geolocation Fields']
-      data = f['HDFEOS']['SWATHS']['AMSR2_L1R']['Data Fields']
+    retv = AmsrObject()
+    with h5py.File(filename, 'r') as f:
+        geoloc = f['HDFEOS']['SWATHS']['AMSR2_L1R']['Geolocation Fields']
+        data = f['HDFEOS']['SWATHS']['AMSR2_L1R']['Data Fields']
       
-      retv.longitude = geoloc['Longitude'][:].ravel()
-      retv.latitude = geoloc['Latitude'][:].ravel()
-      retv.sec1993 = geoloc['tai93time'][:]
-      retv.lwp_mm = data['CloudWaterPath'][:].ravel()
-  if f:
-      f.close()
-  return retv
+        retv.longitude = geoloc['Longitude'][:].ravel()
+        retv.latitude = geoloc['Latitude'][:].ravel()
+        retv.sec1993 = geoloc['tai93time'][:]
+        retv.lwp_mm = data['CloudWaterPath'][:].ravel()
+    if f:
+        f.close()
+    return retv
   
 
 def read_amsre_hdf4(filename):

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -50,15 +50,12 @@ def get_amsr_rof(SETTINGS, imager):
     """ Get radius of influence as a function of overlap and imager pixel size. """
     if SETTINGS['AMSR_IMAGER_RADIUS'] < 0:
         if imager == 'seviri':
-            # pixel size 4.8 x 3 km
-            imager_radius = 5660.
+            imager_radius = SETTINGS['AMSR_SEVIRI_PIXEL_RADIUS']
         elif imager == 'avhrr':
-            # pixel size 4.3 x 3 km
-            imager_radius = 5325
-        elif imager == 'viirs':
-            pass
-        elif imager == 'modis':
-            pass
+            imager_radius = SETTINGS['AMSR_GAC_PIXEL_RADIUS']
+        else:
+            imager_radius = SETTINGS['AMSR_IMAGER_1KM_PIXEL_RADIUS']
+            
     return calculate_amsr_rof(SETTINGS['AMSR_OVERLAP'], imager_radius)
 
 

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -37,6 +37,8 @@ logger = logging.getLogger(__name__)
 def calculate_amsr_rof(overlap, imager_radius):
     """ Calculate radius of influence for nearest neighbour search. 
         
+        A AMSR footprint of the 36GHz channel (7x12 km) is assumed.
+        
         100% overlap:  fov_semi_minor_axis_diam / 2 -IMAGER_RADIUS
         50% overlap :  fov_semi_minor_axis_diam / 2 
         25% overlap:  fov_semi_minor_axis_diam / 2  + 0.5*IMAGER_RADIUS

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 AMSR_RADIUS = 5.4e3  # 3.7e3 to include 5km pixels parly overlapping amsr-e footprint
 
 
-def get_amsr(filename):
+def get_amsr(filename, SETTINGS):
 
     if SETTINGS['AMSR_SENSOR'].lower() in ['amsre', 'amsr-e']:
         AMSR_SENSOR = 'AMSR-E'

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -151,6 +151,9 @@ def read_amsr2_he5(filename):
         retv.latitude = geoloc['Latitude'][:].ravel()
         retv.sec1993 = geoloc['tai93time'][:]
         retv.lwp_mm = data['CloudWaterPath'][:].ravel()
+        retv.pixel_status = data['PixelStatus'][:].ravel()
+        retv.quality = data['QualityFlag'][:].ravel()
+        retv.surface_type = data['SurfaceTypeIndex'][:].ravel()
     if f:
         f.close()
     return retv

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -43,8 +43,8 @@ def calculate_amsr_rof(overlap, imager_radius):
         50% overlap :  fov_semi_minor_axis_diam / 2 
         25% overlap:  fov_semi_minor_axis_diam / 2  + 0.5*IMAGER_RADIUS
     """
-    fov_semi_minor_axis_diam = 7000.
-    rof = 0.5*fov_semi_minor_axis_diam + imager_radius - 2*overlap*imager_radius
+    fov_semi_minor_diam = config.AMSR_SEMI_MINOR_DIAMETER
+    rof = 0.5*fov_semi_minor_diam + imager_radius - 2*overlap*imager_radius
     return rof
 
 

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -53,6 +53,9 @@ def get_amsr_rof(SETTINGS, imager):
     imager_radius = SETTINGS['AMSR_IMAGER_PIXEL_RADIUS']
     overlap = SETTINGS['AMSR_OVERLAP']   
     
+    if imager_radius < 0:
+        raise Exception('Imager radius cannot be < 0.')
+    
     if overlap < 0 or overlap > 1:
         raise Exception('AMSR_OVERLAP in SETTINGS has to be [0, 1]. ' \
                         'Your overlap is {}'.format(overlap))

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -48,13 +48,13 @@ def calculate_amsr_rof(overlap, imager_radius):
 
 def get_amsr_rof(SETTINGS, imager):
     """ Get radius of influence as a function of overlap and imager pixel size. """
-    if SETTINGS['AMSR_IMAGER_RADIUS'] < 0:
-        if imager == 'seviri':
-            imager_radius = SETTINGS['AMSR_SEVIRI_PIXEL_RADIUS']
-        elif imager == 'avhrr':
-            imager_radius = SETTINGS['AMSR_GAC_PIXEL_RADIUS']
-        else:
-            imager_radius = SETTINGS['AMSR_IMAGER_1KM_PIXEL_RADIUS']
+    
+    if imager == 'seviri':
+        imager_radius = SETTINGS['AMSR_SEVIRI_PIXEL_RADIUS']
+    elif imager == 'avhrr':
+        imager_radius = SETTINGS['AMSR_GAC_PIXEL_RADIUS']
+    else:
+        imager_radius = SETTINGS['AMSR_IMAGER_1KM_PIXEL_RADIUS']
             
     return calculate_amsr_rof(SETTINGS['AMSR_OVERLAP'], imager_radius)
 

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -52,6 +52,10 @@ def get_amsr_rof(SETTINGS, imager):
     """ Get radius of influence as a function of overlap and imager pixel size. """
     imager_radius = SETTINGS['AMSR_IMAGER_PIXEL_RADIUS']
     overlap = SETTINGS['AMSR_OVERLAP']   
+    
+    if overlap < 0 or overlap > 1:
+        raise Exception('AMSR_OVERLAP in SETTINGS has to be [0, 1]. ' \
+                        'Your overlap is {}'.format(overlap))
     return calculate_amsr_rof(overlap, imager_radius)
 
 

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -50,15 +50,9 @@ def calculate_amsr_rof(overlap, imager_radius):
 
 def get_amsr_rof(SETTINGS, imager):
     """ Get radius of influence as a function of overlap and imager pixel size. """
-    
-    if imager == 'seviri':
-        imager_radius = SETTINGS['AMSR_SEVIRI_PIXEL_RADIUS']
-    elif imager == 'avhrr':
-        imager_radius = SETTINGS['AMSR_GAC_PIXEL_RADIUS']
-    else:
-        imager_radius = SETTINGS['AMSR_IMAGER_1KM_PIXEL_RADIUS']
-            
-    return calculate_amsr_rof(SETTINGS['AMSR_OVERLAP'], imager_radius)
+    imager_radius = SETTINGS['AMSR_IMAGER_PIXEL_RADIUS']
+    overlap = SETTINGS['AMSR_OVERLAP']   
+    return calculate_amsr_rof(overlap, imager_radius)
 
 
 def get_amsr(filename, SETTINGS):

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -232,10 +232,10 @@ def match_amsr_imager(amsr, cloudproducts, SETTINGS):
     if config.RESOLUTION == 5:
         n_neighbours = 5
     
-    if SETTINGS['AMSR_RADIUS'] < 0:
+    if SETTINGS['AMSR_ROF'] < 0:
         AMSR_RADIUS = get_amsr_rof(SETTINGS, cloudproducts.imager)
     else:
-        AMSR_RADIUS = SETTINGS['AMSR_RADIUS']
+        AMSR_RADIUS = SETTINGS['AMSR_ROF']
         
     mapper_and_dist = map_imager_distances(cloudproducts,
                                            amsr.longitude.ravel(),

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -28,6 +28,7 @@ import h5py
 import numpy as np
 from datetime import datetime
 from calendar import timegm
+
 TAI93 = datetime(1993, 1, 1)
 
 logger = logging.getLogger(__name__)
@@ -101,7 +102,6 @@ def read_amsr2_h5(filename):
     if f:
         f.close()
     return retv
-
 
 
 def read_amsre_hdf4(filename):

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -119,7 +119,7 @@ def read_amsre_h5(filename):
         retv.sec1993 = f['Swath1/Geolocation Fields/Time']['Time'][:]
         # description='lwp (mm)',
         lwp_gain = f['Swath1/Data Fields/High_res_cloud'].attrs['Scale']  # .ravel()
-        retv.lwp_mm = f['Swath1/Data Fields/High_res_cloud'][:].ravel() * lwp_gain
+        retv.lwp_mm = np.squeeze(f['Swath1/Data Fields/High_res_cloud'][:]).ravel() * lwp_gain
     if f:
         f.close()
     return retv

--- a/atrain_match/truths/amsr.py
+++ b/atrain_match/truths/amsr.py
@@ -66,7 +66,7 @@ def get_amsr(filename):
     logger.info("Extract {} lwp between 0 and {} g/m-2".format(AMSR_SENSOR,
                                                                LWP_THRESHOLD))
     use_amsr = np.logical_and(retv.lwp >= 0,
-                              retv.lwp < LWP_THRESHOLD * 100)
+                              retv.lwp < LWP_THRESHOLD)
     retv = retv.extract_elements(idx=use_amsr)
     return retv
 

--- a/atrain_match/utils/runutils.py
+++ b/atrain_match/utils/runutils.py
@@ -63,7 +63,9 @@ def read_config_info():
             value_ = False
         elif len(values) == 1 and re.match(r"\d+.*\d*", values[0]):
             value_ = np.float(values[0])
-
+        elif name in ['AMSR_SENSOR']:
+            value_ = values[0]
+    
         SETTINGS[name.upper()] = value_
 
     if (SETTINGS['COMPILE_RESULTS_SEPARATELY_FOR_SINGLE_LAYERS_ETC'] or

--- a/atrain_match/utils/runutils.py
+++ b/atrain_match/utils/runutils.py
@@ -65,6 +65,9 @@ def read_config_info():
             value_ = np.float(values[0])
         elif name in ['AMSR_SENSOR']:
             value_ = values[0]
+        elif name in ['AMSR_ROF', 'AMSR_OVERLAP', 'AMSR_GAC_PIXEL_RADIUS', 
+                      'AMSR_SEVIRI_PIXEL_RADIUS', 'AMSR_IMAGER_1KM_PIXEL_RADIUS']:
+            value_ = float(values[0])
     
         SETTINGS[name.upper()] = value_
 

--- a/atrain_match/utils/runutils.py
+++ b/atrain_match/utils/runutils.py
@@ -65,8 +65,7 @@ def read_config_info():
             value_ = np.float(values[0])
         elif name in ['AMSR_SENSOR']:
             value_ = values[0]
-        elif name in ['AMSR_ROF', 'AMSR_OVERLAP', 'AMSR_GAC_PIXEL_RADIUS', 
-                      'AMSR_SEVIRI_PIXEL_RADIUS', 'AMSR_IMAGER_1KM_PIXEL_RADIUS']:
+        elif name in ['AMSR_ROF', 'AMSR_OVERLAP', 'AMSR_IMAGER_PIXEL_RADIUS']:
             value_ = float(values[0])
     
         SETTINGS[name.upper()] = value_


### PR DESCRIPTION
Hi,

as already mentioned in the issues section I wanted to add AMSR2 support for LWP validation we need in ESA Cloud_cci+. I first tried to implement the simpler solution to just adapt the reader and then proceed with the existing AMSR-E processing chain. I tested the changed and they seem to work fine. In this PR I wanted to show you more concrete what I wanted to do.

What is your opninion on that ?

Cheers,
Daniel

PS: Because the CCI integration PR #4 is not merged yet, these commits are also included in this PR.